### PR TITLE
Fixed off-by-1 overflow

### DIFF
--- a/sxml.c
+++ b/sxml.c
@@ -162,10 +162,11 @@ typedef struct
 static BOOL state_pushtoken (sxml_t* state, sxml_args_t* args, sxmltype_t type, const char* start, const char* end)
 {
 	sxmltok_t* token;
-	UINT i= state->ntokens++;
-	if (args->num_tokens < state->ntokens)
+	UINT i;
+	if (args->num_tokens <= state->ntokens)
 		return FALSE;
-	
+
+	i = state->ntokens++;
 	token= &args->tokens[i];
 	token->type= type;
 	token->startpos= buffer_tooffset (args, start);


### PR DESCRIPTION
Found with Libfuzzer

```
==12867==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffe749d2b22 at pc 0x7fe0607e3c4d bp 0x7ffe749d1bc0 sp 0x7ffe749d1bb8
WRITE of size 2 at 0x7ffe749d2b22 thread T0
    #0 0x7fe0607e3c4c in parse_attributes /home/polka/fuzz/sxml/sxml-repo/sxml.c:295:14
    #1 0x7fe0607e2154 in parse_start /home/polka/fuzz/sxml/sxml-repo/sxml.c:409:7
    #2 0x7fe0607e1563 in sxml_parse /home/polka/fuzz/sxml/sxml-repo/sxml.c:562:17
    #3 0x4edd7b in main /home/polka/fuzz/sxml/sxml-repo/sxml_test2.c:189:18
    #4 0x7fe05f82eb96 in __libc_start_main /build/glibc-OTsEL5/glibc-2.27/csu/../csu/libc-start.c:310
    #5 0x41b009 in _start (/home/polka/fuzz/sxml/sxml-repo/sxml2+0x41b009)

Address 0x7ffe749d2b22 is located in stack of thread T0 at offset 2722 in frame
    #0 0x4eda0f in main /home/polka/fuzz/sxml/sxml-repo/sxml_test2.c:160

  This frame has 4 object(s):
    [32, 1056) 'buffer' (line 162)
    [1184, 2720) 'tokens' (line 166) <== Memory access at offset 2722 overflows this variable
    [2848, 2852) 'indent' (line 169)
    [2864, 2876) 'parser' (line 175)
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow /home/polka/fuzz/sxml/sxml-repo/sxml.c:295:14 in parse_attributes
Shadow bytes around the buggy address:
  0x10004e932510: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10004e932520: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10004e932530: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10004e932540: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10004e932550: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x10004e932560: 00 00 00 00[f2]f2 f2 f2 f2 f2 f2 f2 f2 f2 f2 f2
  0x10004e932570: f2 f2 f2 f2 04 f2 00 04 f3 f3 f3 f3 00 00 00 00
  0x10004e932580: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10004e932590: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10004e9325a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10004e9325b0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==12867==ABORTING

```